### PR TITLE
handle version incompatibilities

### DIFF
--- a/tasks/documentation.js
+++ b/tasks/documentation.js
@@ -11,7 +11,8 @@ module.exports = function(grunt) {
 
     var path = require('path'),
         chalk = require('chalk'),
-        documentation = require('documentation');
+        documentation = require('documentation').build || require('documentation'),
+        formats = require('documentation').formats;
 
     grunt.registerMultiTask('documentation', 'Use Grunt with documentation to generate great documentation for your JavaScript projects.', function() {
         var options = this.options({
@@ -22,9 +23,9 @@ module.exports = function(grunt) {
             order: []
         });
 
-        var formatter = documentation.formats[options.format];
+        var formatter = formats[options.format];
         if (!formatter) {
-            throw new Error('invalid format given: valid options are ' + Object.keys(documentation.formats).join(', '));
+            throw new Error('invalid format given: valid options are ' + Object.keys(formats).join(', '));
         }
 
         var docOptions = {


### PR DESCRIPTION
Fixes #6 

It looks like referencing documentation@latest leads to grunt-documentation pulling in the incompatable 4.x version. This should make it compatible with both 3.x and 4.x.
